### PR TITLE
Add circles to map of cities with an open budget

### DIFF
--- a/offenerhaushalt/static/js/home.js
+++ b/offenerhaushalt/static/js/home.js
@@ -69,7 +69,22 @@ $(function() {
 	        .transition()
 	        .duration(400)
 	        .style('fill', '#555');
-	    
+
+      cities = sites.sites.map(function(d) { return d.location; })
+      cities = $.grep(cities,function(n){ return(n) });
+      svg.selectAll('circle')
+      .data(cities)
+      .enter()
+      .append('circle')
+      .attr("cx", function(d) {
+        return projection([d.longitude, d.latitude])[0];
+      })
+      .attr("cy", function(d) {
+        return projection([d.longitude, d.latitude])[1];
+      })
+      .attr("r", 4)
+      .style("fill", "#fff")
+      .style("stroke", "#428bca");
     }
 
     function renderListing(state) {

--- a/sites/bonn.yaml
+++ b/sites/bonn.yaml
@@ -6,6 +6,9 @@ source_url: http://opendata.bonn.de/
 data_url: http://opendatalabs.org/misc/Plan_Haushalt_2013_2014-4-xlsx.csv
 state: NW
 level: kommune
+location:
+  latitude: 50.7371862
+  longitude: 7.0965505
 dataset: de-bonn
 default: produkte
 

--- a/sites/laatzen.yaml
+++ b/sites/laatzen.yaml
@@ -6,6 +6,9 @@ source_url: http://www.laatzen.de/
 data_url: http://opendatalabs.org/de/haushalt
 state: NI
 level: kommune
+location:
+  latitude: 52.3088889
+  longitude: 9.8019002
 dataset: stadtlaatzenplan2013
 default: produkte
 

--- a/sites/osnabrueck.yaml
+++ b/sites/osnabrueck.yaml
@@ -6,6 +6,9 @@ source_url: http://www.osnabrueck.de/
 data_url: http://opendatalabs.org/de/haushalt
 state: NI
 level: kommune
+location:
+  latitude: 52.279562
+  longitude: 8.0470611
 dataset: hhos
 default: fachbereiche
 

--- a/sites/uelzen.yaml
+++ b/sites/uelzen.yaml
@@ -5,6 +5,9 @@ source: "Titus Tschamtke, Rolf Tischler"
 data_url: "http://www.titusgames.de/Haushaltsdaten_2012_bis_2014.csv"
 state: NI
 level: kommune
+location:
+  latitude: 52.9653701
+  longitude: 10.5587693
 dataset: uelzen
 default: produkte
 

--- a/sites/ulm.yaml
+++ b/sites/ulm.yaml
@@ -6,6 +6,9 @@ _source_url: http://www.laatzen.de/
 data_url: http://beta.shutterworks.org/hh/out.csv
 state: BW
 level: kommune
+location:
+  latitude: 48.4000363
+  longitude: 9.9845997
 dataset: haushalt_ulm
 default: produktbereiche
 


### PR DESCRIPTION
### Change:

Adds circles to map for cities with an open budget.
closes #11 
### Screenshot:

![bildschirmfoto 2014-08-07 um 11 15 50](https://cloud.githubusercontent.com/assets/688980/3839632/816cd62e-1e13-11e4-8634-c4eff8de8793.png)
