### PR TITLE
Remove Europa link from navigation

### DIFF
--- a/offenerhaushalt/templates/layout.html
+++ b/offenerhaushalt/templates/layout.html
@@ -25,9 +25,6 @@
             <li>
               <a href="/#kommunen">Kommunen</a>
             </li>
-            <li class="hidden-sm">
-              <a href="/page/europa.html">Europa</a>
-            </li>
             <li>
               <a href="/page/intro.html">Über uns</a>
             </li>


### PR DESCRIPTION
Removes the Europa link from the navigation. Request from @pudo closes #10 
