### PR TITLE
Add münster to offenerhaushalt

### DIFF
--- a/sites/muenster.yaml
+++ b/sites/muenster.yaml
@@ -1,0 +1,25 @@
+name: Stadt Münster
+slug: muenster
+tagline: "Haushaltsplan 2009-2012 der Stadt Münster."
+source: Code for Münster
+source_url: http://codeformuenster.org/
+data_url: https://gist.githubusercontent.com/milafrerichs/fb6508b5fe0bd6a1ebd2/raw/a3b9b349119f5a2655f8ee167633e4e838150967/haushalt_gesamt.txt
+state: NW
+level: kommune
+dataset: de-muenster-gesamt
+default: produktgruppe
+
+filters:
+  - field: 'time.year'
+    name: 'Jahr'
+    default: 2012
+  - field: 'Typ'
+    name: 'Art'
+    default: 'Ausgaben'
+
+hierarchies:
+    produktgruppe:
+        name: Fachbereich
+        drilldowns:
+            - Produktgruppe
+            - Untergruppe


### PR DESCRIPTION
Münster ist jetzt endlich auch in OpenSpending und somit dann auch hier im offenen Haushalt.

@pudo willst du da kurz drüber schauen?

Danke.
![bildschirmfoto 2014-10-16 um 08 52 41](https://cloud.githubusercontent.com/assets/688980/4658629/0fe36b9c-5501-11e4-98e7-b9436d1beae7.png)
