### PR TITLE
Add sitemap for google

### DIFF
--- a/page/bundesland/BB.html
+++ b/page/bundesland/BB.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/BB/
 land: Brandenburg
 code: BB
+sitemap: false
 ---
-

--- a/page/bundesland/BE.html
+++ b/page/bundesland/BE.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/BE/
 land: Berlin
 code: BE
+sitemap: false
 ---
-

--- a/page/bundesland/BW.html
+++ b/page/bundesland/BW.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/BW/
 land: Baden-Württemberg
 code: BW
+sitemap: false
 ---
-

--- a/page/bundesland/BY.html
+++ b/page/bundesland/BY.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/BY/
 land: Bayern
 code: BY
+sitemap: false
 ---
-

--- a/page/bundesland/HB.html
+++ b/page/bundesland/HB.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/HB/
 land: Bremen
 code: HB
+sitemap: false
 ---
-

--- a/page/bundesland/HE.html
+++ b/page/bundesland/HE.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/HE/
 land: Hessen
 code: HE
+sitemap: false
 ---
-

--- a/page/bundesland/HH.html
+++ b/page/bundesland/HH.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/HH/
 land: Hamburg
 code: HH
+sitemap: false
 ---
-

--- a/page/bundesland/MV.html
+++ b/page/bundesland/MV.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/MV/
 land: Mecklenburg-Vorpommern
 code: MV
+sitemap: false
 ---
-

--- a/page/bundesland/NI.html
+++ b/page/bundesland/NI.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/NI/
 land: Niedersachsen
 code: NI
+sitemap: false
 ---
-

--- a/page/bundesland/NW.html
+++ b/page/bundesland/NW.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/NW/
 land: Nordrhein-Westfalen
 code: NW
+sitemap: false
 ---
-

--- a/page/bundesland/RP.html
+++ b/page/bundesland/RP.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/RP/
 land: Rheinland-Pfalz
 code: RP
+sitemap: false
 ---
-

--- a/page/bundesland/SH.html
+++ b/page/bundesland/SH.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/SH/
 land: Schlewig-Holstein
 code: SH
+sitemap: false
 ---
-

--- a/page/bundesland/SL.html
+++ b/page/bundesland/SL.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/SL/
 land: Saarland
 code: SL
+sitemap: false
 ---
-

--- a/page/bundesland/SN.html
+++ b/page/bundesland/SN.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/SN/
 land: Sachsen
 code: SN
+sitemap: false
 ---
-

--- a/page/bundesland/ST.html
+++ b/page/bundesland/ST.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/ST/
 land: Sachsen-Anhalt
 code: ST
+sitemap: false
 ---
-

--- a/page/bundesland/TH.html
+++ b/page/bundesland/TH.html
@@ -3,5 +3,5 @@ layout: bundesland
 permalink: /bundesland/TH/
 land: Thüringen
 code: TH
+sitemap: false
 ---
-

--- a/page/bundesland/bund.html
+++ b/page/bundesland/bund.html
@@ -3,6 +3,6 @@ layout: bundesland
 permalink: /bundesland/
 land: Bundesland
 code: DE
+sitemap: false
 ---
 {% include bund.html %}
-

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,51 @@
+---
+layout: null
+---
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd" xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+
+  <!-- posts -->
+  {% for post in site.posts %}
+    {% if post.sitemap == false %}{% continue %}{% endif %}
+    <url>
+      <loc>{{ site.url }}{{ post.url }}</loc>
+      {% if post.lastmod == null %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      {% else %}
+        <lastmod>{{ post.date | date_to_xmlschema }}</lastmod>
+      {% endif %}
+      <changefreq>weekly</changefreq>
+      <priority>1.0</priority>
+    </url>
+  {% endfor %}
+
+  <!-- pages -->
+  {% for page in site.pages %}
+    {% if page.sitemap == false %}{% continue %}{% endif %}
+    {% if page.url contains 'static' %}{% continue %}{% endif %}
+    <url>
+      <loc>{{ site.url }}{{ page.url }}</loc>
+      <lastmod>{{ 'now' | date_to_xmlschema }}</lastmod>
+      <changefreq>weekly</changefreq>
+      <priority>1.0</priority>
+     </url>
+  {% endfor %}
+
+  <!-- haushalte -->
+  {% for haushalt in site.haushalte %}
+    {% if haushalt.sitemap == false %}{% continue %}{% endif %}
+    {% if haushalt.name == '' %}{% continue %}{% endif %}
+    {% if haushalt.layout != 'budget2' %}{% continue %}{% endif %}
+    <url>
+      <loc>{{ site.url }}{{ haushalt.url }}</loc>
+      <lastmod>{{ 'now' | date_to_xmlschema }}</lastmod>
+      {% if haushalt.config %}
+        <changefreq>weekly</changefreq>
+        <priority>1.0</priority>
+      {% else %}
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
+      {% endif %}
+     </url>
+  {% endfor %}
+</urlset>


### PR DESCRIPTION
We cannot use a handy plugin like https://github.com/jekyll/jekyll-sitemap here because of the "special" way the collection works (it contains dupliacte content for some reason). So we need to build it manually.

The posts part is actually empty.

The pages show the content pages. For some reason we need to manually exclude some static files here. Might be a missing config somewhere.

The haushalte list all haushalte but switch the  changefreq based on their content – more often if they have content. This is just for fun, google will to what it wants anyway.

The page/bundesland/* are excluded here since their layout seems to be broken.