### PR TITLE
Fix frontmatter for multiple _haushalte-files

### DIFF
--- a/_haushalte/BB/Alt-Zauche.md
+++ b/_haushalte/BB/Alt-Zauche.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Alt Zauche
-    level: kommune
-    state: BB
-    slug: Alt-Zauche
-
-    ---
-
-
-    
+layout: budget2
+name: Alt Zauche
+level: kommune
+state: BB
+slug: Alt-Zauche
+---

--- a/_haushalte/BB/Beiersdorf.md
+++ b/_haushalte/BB/Beiersdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Beiersdorf
-    level: kommune
-    state: BB
-    slug: Beiersdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Beiersdorf
+level: kommune
+state: BB
+slug: Beiersdorf
+---

--- a/_haushalte/BB/Berkholz.md
+++ b/_haushalte/BB/Berkholz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Berkholz
-    level: kommune
-    state: BB
-    slug: Berkholz
-
-    ---
-
-
-    
+layout: budget2
+name: Berkholz
+level: kommune
+state: BB
+slug: Berkholz
+---

--- a/_haushalte/BB/Blankenfelde.md
+++ b/_haushalte/BB/Blankenfelde.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Blankenfelde
-    level: kommune
-    state: BB
-    slug: Blankenfelde
-
-    ---
-
-
-    
+layout: budget2
+name: Blankenfelde
+level: kommune
+state: BB
+slug: Blankenfelde
+---

--- a/_haushalte/BB/Bleyen.md
+++ b/_haushalte/BB/Bleyen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Bleyen
-    level: kommune
-    state: BB
-    slug: Bleyen
-
-    ---
-
-
-    
+layout: budget2
+name: Bleyen
+level: kommune
+state: BB
+slug: Bleyen
+---

--- a/_haushalte/BB/Brieskow.md
+++ b/_haushalte/BB/Brieskow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Brieskow
-    level: kommune
-    state: BB
-    slug: Brieskow
-
-    ---
-
-
-    
+layout: budget2
+name: Brieskow
+level: kommune
+state: BB
+slug: Brieskow
+---

--- a/_haushalte/BB/Byhleguhre.md
+++ b/_haushalte/BB/Byhleguhre.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Byhleguhre
-    level: kommune
-    state: BB
-    slug: Byhleguhre
-
-    ---
-
-
-    
+layout: budget2
+name: Byhleguhre
+level: kommune
+state: BB
+slug: Byhleguhre
+---

--- a/_haushalte/BB/Carmzow.md
+++ b/_haushalte/BB/Carmzow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Carmzow
-    level: kommune
-    state: BB
-    slug: Carmzow
-
-    ---
-
-
-    
+layout: budget2
+name: Carmzow
+level: kommune
+state: BB
+slug: Carmzow
+---

--- a/_haushalte/BB/Dallgow.md
+++ b/_haushalte/BB/Dallgow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Dallgow
-    level: kommune
-    state: BB
-    slug: Dallgow
-
-    ---
-
-
-    
+layout: budget2
+name: Dallgow
+level: kommune
+state: BB
+slug: Dallgow
+---

--- a/_haushalte/BB/Diensdorf.md
+++ b/_haushalte/BB/Diensdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Diensdorf
-    level: kommune
-    state: BB
-    slug: Diensdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Diensdorf
+level: kommune
+state: BB
+slug: Diensdorf
+---

--- a/_haushalte/BB/Dissen.md
+++ b/_haushalte/BB/Dissen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Dissen
-    level: kommune
-    state: BB
-    slug: Dissen
-
-    ---
-
-
-    
+layout: budget2
+name: Dissen
+level: kommune
+state: BB
+slug: Dissen
+---

--- a/_haushalte/BB/Doberlug.md
+++ b/_haushalte/BB/Doberlug.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Doberlug
-    level: kommune
-    state: BB
-    slug: Doberlug
-
-    ---
-
-
-    
+layout: budget2
+name: Doberlug
+level: kommune
+state: BB
+slug: Doberlug
+---

--- a/_haushalte/BB/Flieth.md
+++ b/_haushalte/BB/Flieth.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Flieth
-    level: kommune
-    state: BB
-    slug: Flieth
-
-    ---
-
-
-    
+layout: budget2
+name: Flieth
+level: kommune
+state: BB
+slug: Flieth
+---

--- a/_haushalte/BB/Fredersdorf.md
+++ b/_haushalte/BB/Fredersdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Fredersdorf
-    level: kommune
-    state: BB
-    slug: Fredersdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Fredersdorf
+level: kommune
+state: BB
+slug: Fredersdorf
+---

--- a/_haushalte/BB/Garzau.md
+++ b/_haushalte/BB/Garzau.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Garzau
-    level: kommune
-    state: BB
-    slug: Garzau
-
-    ---
-
-
-    
+layout: budget2
+name: Garzau
+level: kommune
+state: BB
+slug: Garzau
+---

--- a/_haushalte/BB/Gorden.md
+++ b/_haushalte/BB/Gorden.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Gorden
-    level: kommune
-    state: BB
-    slug: Gorden
-
-    ---
-
-
-    
+layout: budget2
+name: Gorden
+level: kommune
+state: BB
+slug: Gorden
+---

--- a/_haushalte/BB/Gosen.md
+++ b/_haushalte/BB/Gosen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Gosen
-    level: kommune
-    state: BB
-    slug: Gosen
-
-    ---
-
-
-    
+layout: budget2
+name: Gosen
+level: kommune
+state: BB
+slug: Gosen
+---

--- a/_haushalte/BB/Groß-Schacksdorf.md
+++ b/_haushalte/BB/Groß-Schacksdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Groß Schacksdorf
-    level: kommune
-    state: BB
-    slug: Groß-Schacksdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Groß Schacksdorf
+level: kommune
+state: BB
+slug: Groß-Schacksdorf
+---

--- a/_haushalte/BB/Grunow.md
+++ b/_haushalte/BB/Grunow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Grunow
-    level: kommune
-    state: BB
-    slug: Grunow
-
-    ---
-
-
-    
+layout: budget2
+name: Grunow
+level: kommune
+state: BB
+slug: Grunow
+---

--- a/_haushalte/BB/Gusow.md
+++ b/_haushalte/BB/Gusow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Gusow
-    level: kommune
-    state: BB
-    slug: Gusow
-
-    ---
-
-
-    
+layout: budget2
+name: Gusow
+level: kommune
+state: BB
+slug: Gusow
+---

--- a/_haushalte/BB/Gülitz.md
+++ b/_haushalte/BB/Gülitz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Gülitz
-    level: kommune
-    state: BB
-    slug: Gülitz
-
-    ---
-
-
-    
+layout: budget2
+name: Gülitz
+level: kommune
+state: BB
+slug: Gülitz
+---

--- a/_haushalte/BB/Halenbeck.md
+++ b/_haushalte/BB/Halenbeck.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Halenbeck
-    level: kommune
-    state: BB
-    slug: Halenbeck
-
-    ---
-
-
-    
+layout: budget2
+name: Halenbeck
+level: kommune
+state: BB
+slug: Halenbeck
+---

--- a/_haushalte/BB/Heckelberg.md
+++ b/_haushalte/BB/Heckelberg.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Heckelberg
-    level: kommune
-    state: BB
-    slug: Heckelberg
-
-    ---
-
-
-    
+layout: budget2
+name: Heckelberg
+level: kommune
+state: BB
+slug: Heckelberg
+---

--- a/_haushalte/BB/Hohenselchow.md
+++ b/_haushalte/BB/Hohenselchow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Hohenselchow
-    level: kommune
-    state: BB
-    slug: Hohenselchow
-
-    ---
-
-
-    
+layout: budget2
+name: Hohenselchow
+level: kommune
+state: BB
+slug: Hohenselchow
+---

--- a/_haushalte/BB/Jämlitz.md
+++ b/_haushalte/BB/Jämlitz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Jämlitz
-    level: kommune
-    state: BB
-    slug: Jämlitz
-
-    ---
-
-
-    
+layout: budget2
+name: Jämlitz
+level: kommune
+state: BB
+slug: Jämlitz
+---

--- a/_haushalte/BB/Kasel.md
+++ b/_haushalte/BB/Kasel.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Kasel
-    level: kommune
-    state: BB
-    slug: Kasel
-
-    ---
-
-
-    
+layout: budget2
+name: Kasel
+level: kommune
+state: BB
+slug: Kasel
+---

--- a/_haushalte/BB/Kleßen.md
+++ b/_haushalte/BB/Kleßen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Kleßen
-    level: kommune
-    state: BB
-    slug: Kleßen
-
-    ---
-
-
-    
+layout: budget2
+name: Kleßen
+level: kommune
+state: BB
+slug: Kleßen
+---

--- a/_haushalte/BB/Krausnick.md
+++ b/_haushalte/BB/Krausnick.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Krausnick
-    level: kommune
-    state: BB
-    slug: Krausnick
-
-    ---
-
-
-    
+layout: budget2
+name: Krausnick
+level: kommune
+state: BB
+slug: Krausnick
+---

--- a/_haushalte/BB/Lichterfeld.md
+++ b/_haushalte/BB/Lichterfeld.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Lichterfeld
-    level: kommune
-    state: BB
-    slug: Lichterfeld
-
-    ---
-
-
-    
+layout: budget2
+name: Lichterfeld
+level: kommune
+state: BB
+slug: Lichterfeld
+---

--- a/_haushalte/BB/Lunow.md
+++ b/_haushalte/BB/Lunow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Lunow
-    level: kommune
-    state: BB
-    slug: Lunow
-
-    ---
-
-
-    
+layout: budget2
+name: Lunow
+level: kommune
+state: BB
+slug: Lunow
+---

--- a/_haushalte/BB/Massen.md
+++ b/_haushalte/BB/Massen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Massen
-    level: kommune
-    state: BB
-    slug: Massen
-
-    ---
-
-
-    
+layout: budget2
+name: Massen
+level: kommune
+state: BB
+slug: Massen
+---

--- a/_haushalte/BB/Neiße.md
+++ b/_haushalte/BB/Neiße.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Neiße
-    level: kommune
-    state: BB
-    slug: Neiße
-
-    ---
-
-
-    
+layout: budget2
+name: Neiße
+level: kommune
+state: BB
+slug: Neiße
+---

--- a/_haushalte/BB/Neu.md
+++ b/_haushalte/BB/Neu.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Neu
-    level: kommune
-    state: BB
-    slug: Neu
-
-    ---
-
-
-    
+layout: budget2
+name: Neu
+level: kommune
+state: BB
+slug: Neu
+---

--- a/_haushalte/BB/Nuthe.md
+++ b/_haushalte/BB/Nuthe.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Nuthe
-    level: kommune
-    state: BB
-    slug: Nuthe
-
-    ---
-
-
-    
+layout: budget2
+name: Nuthe
+level: kommune
+state: BB
+slug: Nuthe
+---

--- a/_haushalte/BB/Ragow.md
+++ b/_haushalte/BB/Ragow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Ragow
-    level: kommune
-    state: BB
-    slug: Ragow
-
-    ---
-
-
-    
+layout: budget2
+name: Ragow
+level: kommune
+state: BB
+slug: Ragow
+---

--- a/_haushalte/BB/Reichenow.md
+++ b/_haushalte/BB/Reichenow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Reichenow
-    level: kommune
-    state: BB
-    slug: Reichenow
-
-    ---
-
-
-    
+layout: budget2
+name: Reichenow
+level: kommune
+state: BB
+slug: Reichenow
+---

--- a/_haushalte/BB/Rietz.md
+++ b/_haushalte/BB/Rietz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Rietz
-    level: kommune
-    state: BB
-    slug: Rietz
-
-    ---
-
-
-    
+layout: budget2
+name: Rietz
+level: kommune
+state: BB
+slug: Rietz
+---

--- a/_haushalte/BB/Rietzneuendorf.md
+++ b/_haushalte/BB/Rietzneuendorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Rietzneuendorf
-    level: kommune
-    state: BB
-    slug: Rietzneuendorf
-
-    ---
-
-
-    
+layout: budget2
+name: Rietzneuendorf
+level: kommune
+state: BB
+slug: Rietzneuendorf
+---

--- a/_haushalte/BB/Schmogrow.md
+++ b/_haushalte/BB/Schmogrow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Schmogrow
-    level: kommune
-    state: BB
-    slug: Schmogrow
-
-    ---
-
-
-    
+layout: budget2
+name: Schmogrow
+level: kommune
+state: BB
+slug: Schmogrow
+---

--- a/_haushalte/BB/Schönwalde.md
+++ b/_haushalte/BB/Schönwalde.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Schönwalde
-    level: kommune
-    state: BB
-    slug: Schönwalde
-
-    ---
-
-
-    
+layout: budget2
+name: Schönwalde
+level: kommune
+state: BB
+slug: Schönwalde
+---

--- a/_haushalte/BB/Sieversdorf.md
+++ b/_haushalte/BB/Sieversdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Sieversdorf
-    level: kommune
-    state: BB
-    slug: Sieversdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Sieversdorf
+level: kommune
+state: BB
+slug: Sieversdorf
+---

--- a/_haushalte/BB/Stechow.md
+++ b/_haushalte/BB/Stechow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Stechow
-    level: kommune
-    state: BB
-    slug: Stechow
-
-    ---
-
-
-    
+layout: budget2
+name: Stechow
+level: kommune
+state: BB
+slug: Stechow
+---

--- a/_haushalte/BB/Storbeck.md
+++ b/_haushalte/BB/Storbeck.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Storbeck
-    level: kommune
-    state: BB
-    slug: Storbeck
-
-    ---
-
-
-    
+layout: budget2
+name: Storbeck
+level: kommune
+state: BB
+slug: Storbeck
+---

--- a/_haushalte/BB/Stüdenitz.md
+++ b/_haushalte/BB/Stüdenitz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Stüdenitz
-    level: kommune
-    state: BB
-    slug: Stüdenitz
-
-    ---
-
-
-    
+layout: budget2
+name: Stüdenitz
+level: kommune
+state: BB
+slug: Stüdenitz
+---

--- a/_haushalte/BB/Temmen.md
+++ b/_haushalte/BB/Temmen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Temmen
-    level: kommune
-    state: BB
-    slug: Temmen
-
-    ---
-
-
-    
+layout: budget2
+name: Temmen
+level: kommune
+state: BB
+slug: Temmen
+---

--- a/_haushalte/BB/Turnow.md
+++ b/_haushalte/BB/Turnow.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Turnow
-    level: kommune
-    state: BB
-    slug: Turnow
-
-    ---
-
-
-    
+layout: budget2
+name: Turnow
+level: kommune
+state: BB
+slug: Turnow
+---

--- a/_haushalte/BB/Uebigau.md
+++ b/_haushalte/BB/Uebigau.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Uebigau
-    level: kommune
-    state: BB
-    slug: Uebigau
-
-    ---
-
-
-    
+layout: budget2
+name: Uebigau
+level: kommune
+state: BB
+slug: Uebigau
+---

--- a/_haushalte/BB/Zernitz.md
+++ b/_haushalte/BB/Zernitz.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Zernitz
-    level: kommune
-    state: BB
-    slug: Zernitz
-
-    ---
-
-
-    
+layout: budget2
+name: Zernitz
+level: kommune
+state: BB
+slug: Zernitz
+---

--- a/_haushalte/BY/Asbach.md
+++ b/_haushalte/BY/Asbach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Asbach
-    level: kommune
-    state: BY
-    slug: Asbach
-
-    ---
-
-
-    
+layout: budget2
+name: Asbach
+level: kommune
+state: BY
+slug: Asbach
+---

--- a/_haushalte/BY/Dörfles.md
+++ b/_haushalte/BY/Dörfles.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Dörfles
-    level: kommune
-    state: BY
-    slug: Dörfles
-
-    ---
-
-
-    
+layout: budget2
+name: Dörfles
+level: kommune
+state: BY
+slug: Dörfles
+---

--- a/_haushalte/BY/Garmisch.md
+++ b/_haushalte/BY/Garmisch.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Garmisch
-    level: kommune
-    state: BY
-    slug: Garmisch
-
-    ---
-
-
-    
+layout: budget2
+name: Garmisch
+level: kommune
+state: BY
+slug: Garmisch
+---

--- a/_haushalte/BY/Gemeinde-im-Landkreis-Main.md
+++ b/_haushalte/BY/Gemeinde-im-Landkreis-Main.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Gemeinde im Landkreis Main
-    level: kommune
-    state: BY
-    slug: Gemeinde-im-Landkreis-Main
-
-    ---
-
-
-    
+layout: budget2
+name: Gemeinde im Landkreis Main
+level: kommune
+state: BY
+slug: Gemeinde-im-Landkreis-Main
+---

--- a/_haushalte/BY/Hilgertshausen.md
+++ b/_haushalte/BY/Hilgertshausen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Hilgertshausen
-    level: kommune
-    state: BY
-    slug: Hilgertshausen
-
-    ---
-
-
-    
+layout: budget2
+name: Hilgertshausen
+level: kommune
+state: BY
+slug: Hilgertshausen
+---

--- a/_haushalte/BY/Höhenkirchen.md
+++ b/_haushalte/BY/Höhenkirchen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Höhenkirchen
-    level: kommune
-    state: BY
-    slug: Höhenkirchen
-
-    ---
-
-
-    
+layout: budget2
+name: Höhenkirchen
+level: kommune
+state: BY
+slug: Höhenkirchen
+---

--- a/_haushalte/BY/Jettingen.md
+++ b/_haushalte/BY/Jettingen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Jettingen
-    level: kommune
-    state: BY
-    slug: Jettingen
-
-    ---
-
-
-    
+layout: budget2
+name: Jettingen
+level: kommune
+state: BY
+slug: Jettingen
+---

--- a/_haushalte/BY/Luhe.md
+++ b/_haushalte/BY/Luhe.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Luhe
-    level: kommune
-    state: BY
-    slug: Luhe
-
-    ---
-
-
-    
+layout: budget2
+name: Luhe
+level: kommune
+state: BY
+slug: Luhe
+---

--- a/_haushalte/BY/Mallersdorf.md
+++ b/_haushalte/BY/Mallersdorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Mallersdorf
-    level: kommune
-    state: BY
-    slug: Mallersdorf
-
-    ---
-
-
-    
+layout: budget2
+name: Mallersdorf
+level: kommune
+state: BY
+slug: Mallersdorf
+---

--- a/_haushalte/BY/Maxhütte.md
+++ b/_haushalte/BY/Maxhütte.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Maxhütte
-    level: kommune
-    state: BY
-    slug: Maxhütte
-
-    ---
-
-
-    
+layout: budget2
+name: Maxhütte
+level: kommune
+state: BY
+slug: Maxhütte
+---

--- a/_haushalte/BY/Missen.md
+++ b/_haushalte/BY/Missen.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Missen
-    level: kommune
-    state: BY
-    slug: Missen
-
-    ---
-
-
-    
+layout: budget2
+name: Missen
+level: kommune
+state: BY
+slug: Missen
+---

--- a/_haushalte/BY/Neu.md
+++ b/_haushalte/BY/Neu.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Neu
-    level: kommune
-    state: BY
-    slug: Neu
-
-    ---
-
-
-    
+layout: budget2
+name: Neu
+level: kommune
+state: BY
+slug: Neu
+---

--- a/_haushalte/BY/Neukirchen-bei-Sulzbach.md
+++ b/_haushalte/BY/Neukirchen-bei-Sulzbach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Neukirchen bei Sulzbach
-    level: kommune
-    state: BY
-    slug: Neukirchen-bei-Sulzbach
-
-    ---
-
-
-    
+layout: budget2
+name: Neukirchen bei Sulzbach
+level: kommune
+state: BY
+slug: Neukirchen-bei-Sulzbach
+---

--- a/_haushalte/BY/Neumarkt.md
+++ b/_haushalte/BY/Neumarkt.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Neumarkt
-    level: kommune
-    state: BY
-    slug: Neumarkt
-
-    ---
-
-
-    
+layout: budget2
+name: Neumarkt
+level: kommune
+state: BY
+slug: Neumarkt
+---

--- a/_haushalte/BY/Oy.md
+++ b/_haushalte/BY/Oy.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Oy
-    level: kommune
-    state: BY
-    slug: Oy
-
-    ---
-
-
-    
+layout: budget2
+name: Oy
+level: kommune
+state: BY
+slug: Oy
+---

--- a/_haushalte/BY/Postbauer.md
+++ b/_haushalte/BY/Postbauer.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Postbauer
-    level: kommune
-    state: BY
-    slug: Postbauer
-
-    ---
-
-
-    
+layout: budget2
+name: Postbauer
+level: kommune
+state: BY
+slug: Postbauer
+---

--- a/_haushalte/BY/Rottach.md
+++ b/_haushalte/BY/Rottach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Rottach
-    level: kommune
-    state: BY
-    slug: Rottach
-
-    ---
-
-
-    
+layout: budget2
+name: Rottach
+level: kommune
+state: BY
+slug: Rottach
+---

--- a/_haushalte/BY/Saaldorf.md
+++ b/_haushalte/BY/Saaldorf.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Saaldorf
-    level: kommune
-    state: BY
-    slug: Saaldorf
-
-    ---
-
-
-    
+layout: budget2
+name: Saaldorf
+level: kommune
+state: BY
+slug: Saaldorf
+---

--- a/_haushalte/BY/Sankt-Oswald.md
+++ b/_haushalte/BY/Sankt-Oswald.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Sankt Oswald
-    level: kommune
-    state: BY
-    slug: Sankt-Oswald
-
-    ---
-
-
-    
+layout: budget2
+name: Sankt Oswald
+level: kommune
+state: BY
+slug: Sankt-Oswald
+---

--- a/_haushalte/BY/Seeon.md
+++ b/_haushalte/BY/Seeon.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Seeon
-    level: kommune
-    state: BY
-    slug: Seeon
-
-    ---
-
-
-    
+layout: budget2
+name: Seeon
+level: kommune
+state: BY
+slug: Seeon
+---

--- a/_haushalte/BY/Staudach.md
+++ b/_haushalte/BY/Staudach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Staudach
-    level: kommune
-    state: BY
-    slug: Staudach
-
-    ---
-
-
-    
+layout: budget2
+name: Staudach
+level: kommune
+state: BY
+slug: Staudach
+---

--- a/_haushalte/BY/Straßlach.md
+++ b/_haushalte/BY/Straßlach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Straßlach
-    level: kommune
-    state: BY
-    slug: Straßlach
-
-    ---
-
-
-    
+layout: budget2
+name: Straßlach
+level: kommune
+state: BY
+slug: Straßlach
+---

--- a/_haushalte/BY/Sulzbach.md
+++ b/_haushalte/BY/Sulzbach.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Sulzbach
-    level: kommune
-    state: BY
-    slug: Sulzbach
-
-    ---
-
-
-    
+layout: budget2
+name: Sulzbach
+level: kommune
+state: BY
+slug: Sulzbach
+---

--- a/_haushalte/BY/Viereth.md
+++ b/_haushalte/BY/Viereth.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Viereth
-    level: kommune
-    state: BY
-    slug: Viereth
-
-    ---
-
-
-    
+layout: budget2
+name: Viereth
+level: kommune
+state: BY
+slug: Viereth
+---

--- a/_haushalte/BY/Weiler.md
+++ b/_haushalte/BY/Weiler.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Weiler
-    level: kommune
-    state: BY
-    slug: Weiler
-
-    ---
-
-
-    
+layout: budget2
+name: Weiler
+level: kommune
+state: BY
+slug: Weiler
+---

--- a/_haushalte/BY/Wernberg.md
+++ b/_haushalte/BY/Wernberg.md
@@ -1,11 +1,7 @@
 ---
-    layout: budget2
-    name: Wernberg
-    level: kommune
-    state: BY
-    slug: Wernberg
-
-    ---
-
-
-    
+layout: budget2
+name: Wernberg
+level: kommune
+state: BY
+slug: Wernberg
+---


### PR DESCRIPTION
The frontmatter does not work with spaces at the front of the variable. So those files did not render correctly.

**Update:**

Github says there are merge conflicts. But I don't see them when looking at
- https://raw.githubusercontent.com/tordans/offenerhaushalt.de/master/_haushalte/BB/Alt-Zauche.md
- vs. https://raw.githubusercontent.com/tordans/offenerhaushalt.de/f03604ab3440cc9e2f1432200f791de3edab78dd/_haushalte/BB/Alt-Zauche.md

Could you try merging it on the "master"?