### PR TITLE
Fix example URLs on help page

### DIFF
--- a/page/hilfestellung-2.html
+++ b/page/hilfestellung-2.html
@@ -95,7 +95,7 @@ script_include: help
       </div>
       <div class="doppik-help account-help" style="display: none">
         <p>
-        <a href="http://offenerhaushalt.de/haushalt/moers/#/administrative_classification?Betrag_Typ=Plan&HH%20Art=Aufwendungen&Jahr=2017">Beispielvisualisierung Doppik Stadt Moers</a>
+        <a href="https://offenerhaushalt.de/haushalt/NW/Moers/">Beispielvisualisierung Doppik Stadt Moers</a>
         </p>
         
         
@@ -104,9 +104,9 @@ script_include: help
         <p>
         In der  <a href="https://www.haushaltssteuerung.de/lexikon-doppik.html">Doppik</a>
         werden die Bezeichnungen nur nach einer
-        Klassifizierung, den Teilhaushalten aufgelistet. Das Buchhaltungssystem Doppik       
+        Klassifizierung, den Teilhaushalten, aufgelistet. Das Buchhaltungssystem Doppik 
         nutzt das Prinzip der doppelten Buchhaltung und wurde in einem Großteil der Bundesländer
-        implementiert . 
+        implementiert.
         </p>
         
         <p>
@@ -132,7 +132,7 @@ script_include: help
       <div class="kameralistik-help account-help" style="display: none">
 
         <p>
-        <a href="https://offenerhaushalt.de/haushalt/nrw/">Beispielvisualisierung Kameralistik Land NRW</a>
+        <a href="https://offenerhaushalt.de/haushalt/NW/nrw/">Beispielvisualisierung Kameralistik Land NRW</a>
         </p>
         
         <h3>Bezeichnungen</h3>


### PR DESCRIPTION
Die Links zu den Beispielen zu den Haushaltstypen Kameralistik und Doppik waren nach dem Refresh von OffenerHaushalt nicht mehr gültig
